### PR TITLE
Pass through simple_mode to ERA5 download

### DIFF
--- a/src/supy/util/_era5.py
+++ b/src/supy/util/_era5.py
@@ -427,6 +427,16 @@ def gen_req_ml(fn_sfc, grid=None, scale=0):
     return dict_req_ml
 
 
+@contextlib.contextmanager
+def chdir(path):
+    orig = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(orig)
+
+
 def download_cds(fn, dict_req):
     import cdsapi
     import tempfile
@@ -439,11 +449,11 @@ def download_cds(fn, dict_req):
         logger_supy.info(f"To download: {fn}")
 
         # this will download the file to a secure temporary directory without requirement for extra permission
-        td = tempfile.gettempdir()
-        os.chdir(td)
-        c.retrieve(**dict_req)
-        # move the downloaded file to desired location
-        shutil.move(path_fn.name, fn)
+        with tempfile.TemporaryDirectory() as td:
+            with chdir(td):
+                c.retrieve(**dict_req)
+                # move the downloaded file to desired location
+                shutil.move(path_fn.name, fn)
         # hold on a bit for the next request
         time.sleep(0.0100)
 


### PR DESCRIPTION
- the first commit fixes an issue I had, when the current working directory was not changed back after chdir-ing into `/tmp`. It now uses a context manager to always do so.
- by using `TemporaryDirectory` we now actually create a directory in `/tmp` and don't store it in the "root" - `tmp`

- The second commit adds the feature of passing through `simple_mode` so when downloading `ERA5` data the ml-files are skipped, which can speed up things a lot.
For this I mostly had to change `gen_ds_diag_era5` to split up the sfc and ml parameters so the latter are only calculated when the data is available.

One thing that is still missing is documentation. Could you point me at places I should add this to a docstring?
could we maybe just copy pasta this one here: https://github.com/UMEP-dev/SuPy/blob/00f7073d796cf21d1fa0a8684837f03088437d09/src/supy/util/_era5.py#L670-L673
